### PR TITLE
Set output of `datalad_release_action release` via GITHUB_OUTPUT

### DIFF
--- a/datalad_release_action/__main__.py
+++ b/datalad_release_action/__main__.py
@@ -77,7 +77,8 @@ def release(dra: DRA) -> None:
     log.info("New version: %s", next_version)
     for pr in prs:
         dra.client.make_release_comments(next_version, pr.number)
-    print(f"::set-output name=new-version::{next_version}")
+    with open(os.environ["GITHUB_OUTPUT"], "a") as fp:
+        print(f"new-version={next_version}", file=fp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>.