### PR TITLE
Make @GITHUBHANDLE into proper markdown hyperref

### DIFF
--- a/changelog.d/pr-26.md
+++ b/changelog.d/pr-26.md
@@ -1,0 +1,3 @@
+### 📝 Documentation
+
+- Make @GITHUBHANDLE into proper markdown hyperref.  [PR #26](https://github.com/datalad/release-action/pull/26) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/changelog.d/templates/new_fragment.md.j2
+++ b/changelog.d/templates/new_fragment.md.j2
@@ -5,6 +5,6 @@
 
 - Describe change, possibly reference closed/related issue/PR.
   Fixes https://github.com/datalad/release-action/issues/XXX via
-  https://github.com/datalad/release-action/pull/XXX (by @GITHUBHANDLE)
+  https://github.com/datalad/release-action/pull/XXX (by [@GITHUBHANDLE](https://github.com/GITHUBHANDLE))
 -->
 {% endfor -%}


### PR DESCRIPTION
To not rely on github ad-hoc dereferencing