### PR TITLE
Fix the concurrency label for the `add-changelog-snippet` workflow

### DIFF
--- a/.github/workflows/add-changelog-snippet.yml
+++ b/.github/workflows/add-changelog-snippet.yml
@@ -11,7 +11,7 @@ on:
 # Prevent the workflow from running multiple jobs at once when a PR is created
 # with multiple labels:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ on:
 # Prevent the workflow from running multiple jobs at once when a PR is created
 # with multiple labels:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label }}
   cancel-in-progress: true
 
 jobs:

--- a/changelog.d/pr-42.md
+++ b/changelog.d/pr-42.md
@@ -1,0 +1,3 @@
+### 🐛 Bug Fixes
+
+- Fix the concurrency label for the `add-changelog-snippet` workflow.  [PR #42](https://github.com/datalad/release-action/pull/42) (by [@jwodder](https://github.com/jwodder))

--- a/populate-workflows.sh
+++ b/populate-workflows.sh
@@ -18,7 +18,7 @@ on:
 # Prevent the workflow from running multiple jobs at once when a PR is created
 # with multiple labels:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Because the workflow triggers on `pull_request_target` rather than `pull_request`, `github.ref_name` will be the name of the base branch (i.e., "master", "maint", or "main"), which means that, if multiple PRs with a CHANGELOG-missing label are opened in quick succession, all but one of the `add-changelog-snippet` workflows for the PRs as a group will be cancelled, which is not want we want.  We want the cancellation to only kick in if multiple runs are started on the same PR at once (which happens if a PR is created with multiple labels), so the concurrency label should use a string that is specific to the head (source) of the PRs.