### PR TITLE
Describe triggering releases via `workflow_dispatch`; error on release if no commits since last tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,17 @@ on:
       #- maint
     types:
       - closed
+  # Allow manually triggering a release via a "Run workflow" button on the
+  # workflow's page:
+  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only run for merged PRs with the "release" label:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    # Only run for manual runs or merged PRs with the "release" label:
+    if: >
+      github.event_name == 'workflow_dispatch'
+         || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ This action prepares a release by performing the following:
   the form `pr-PRNUM.md` or `pr-PRNUM.rst` are inspected in order to determine
   the maximum version bump level.
 
-- The highest-versioned tag of the form `N.N.N` after stripping `tag-prefix`
-  (It is an error if there are no such tags) is used as the previous release
-  version, and it is bumped by the version bump level to obtain the version for
-  the new release.
+- The highest-versioned tag that is of the form `N.N.N` after stripping
+  `tag-prefix` (It is an error if there is no such tag or if there have been no
+  commits to the repository's default branch since the highest tag) is used as
+  the previous release version, and it is bumped by the version bump level to
+  obtain the version for the new release.
 
 - A comment is made on all pull requests from step 1 and on the issues that
   they close mentioning the new release.

--- a/README.md
+++ b/README.md
@@ -248,12 +248,17 @@ on:
       - maint
     types:
       - closed
+  # Allow manually triggering a release via a "Run workflow" button on the
+  # workflow's page:
+  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only run for merged PRs with the "release" label:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    # Only run for manual runs or merged PRs with the "release" label:
+    if: >
+      github.event_name == 'workflow_dispatch'
+         || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/changelog.d/pr-51.md
+++ b/changelog.d/pr-51.md
@@ -1,0 +1,3 @@
+### 🚀 Enhancements and New Features
+
+- Describe triggering releases via `workflow_dispatch`; error on release if no commits since last tag.  Fixes [#34](https://github.com/datalad/release-action/issues/34) via [PR #51](https://github.com/datalad/release-action/pull/51) (by [@jwodder](https://github.com/jwodder))

--- a/datalad_release_action/__main__.py
+++ b/datalad_release_action/__main__.py
@@ -12,7 +12,7 @@ from ghrepo import GHRepo
 from .client import Client, PullRequest
 from .config import Config
 from .util import strip_prefix
-from .versions import Bump, bump_version, get_highest_version_tag
+from .versions import Bump, bump_version, commits_since_tag, get_highest_version_tag
 
 log = logging.getLogger(__name__)
 
@@ -118,6 +118,8 @@ def release(dra: DRA) -> None:
     log.info("Version bump level for this release: %s", bump.value)
     prev_tag = get_highest_version_tag(dra.config.tag_prefix)
     log.info("Previous released tag: %s", prev_tag)
+    if commits_since_tag(prev_tag) == 0:
+        raise click.UsageError(f"No commits made since previous tag {prev_tag}")
     prev_version = strip_prefix(prefix=dra.config.tag_prefix, s=prev_tag)
     log.info("Previous released version: %s", prev_version)
     next_version = bump_version(prev_version, bump)

--- a/datalad_release_action/versions.py
+++ b/datalad_release_action/versions.py
@@ -114,3 +114,13 @@ def highest_version_tag(tag_prefix: str, tags: Iterable[str]) -> str:
             f"Repository does not have any tags of the form {tag_prefix}N.N.N"
         )
     return max_tag
+
+
+def commits_since_tag(tag: str) -> int:
+    r = subprocess.run(
+        ["git", "rev-list", "--count", f"{tag}.."],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return int(r.stdout.strip())

--- a/populate-workflows.sh
+++ b/populate-workflows.sh
@@ -53,12 +53,17 @@ on:
       - maint
     types:
       - closed
+  # Allow manually triggering a release via a "Run workflow" button on the
+  # workflow's page:
+  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only run for merged PRs with the "release" label:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    # Only run for manual runs or merged PRs with the "release" label:
+    if: >
+      github.event_name == 'workflow_dispatch'
+         || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #34.

This PR updates the sample release workflow in the README and the release workflow created by `populate-workflows.sh` to trigger releases on `workflow_dispatch` in addition to PR merges.  The release action is also modified to error if there have been no commits to the releasing repository since the previous version tag.

After this is merged & released (or before, if you're not concerned about people manually making releases without commits in between), the `release.yml` workflows for datalad and any other projects that use this will have to be updated to use `workflow_dispatch` as shown in this PR.  In addition, https://github.com/datalad/datalad/blob/HEAD/CONTRIBUTING.md#releasing-with-github-actions-auto-and-pull-requests should be updated.